### PR TITLE
Removed redundant intersection loop

### DIFF
--- a/strsimpy/sorensen_dice.py
+++ b/strsimpy/sorensen_dice.py
@@ -44,8 +44,5 @@ class SorensenDice(ShingleBased, NormalizedStringDistance, NormalizedStringSimil
             union.add(k)
         for k in profile1.keys():
             union.add(k)
-        inter = 0
-        for k in union:
-            if k in profile0.keys() and k in profile1.keys():
-                inter += 1
+        inter = int(len(profile0.keys()) + len(profile1.keys()) - len(union))
         return 2.0 * inter / (len(profile0) + len(profile1))


### PR DESCRIPTION
Since we already have the set union, calculating the intersection length is possible without looping like this: |A|+|B|-U(A,B).  As already implemented in the Jaccard measure.