### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/strsimpy/sift4_test.py
+++ b/strsimpy/sift4_test.py
@@ -14,7 +14,7 @@ class SIFT4Test(unittest.TestCase):
         ]
 
         for a, b, offset, res in results:
-            self.assertEquals(res, s.distance(a, b, maxoffset=offset))
+            self.assertEqual(res, s.distance(a, b, maxoffset=offset))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The aliases were deprecated and removed in Python 3.11.

Ref : python/cpython#28268

assertEquals -> assertEqual